### PR TITLE
feat: update step to use actions/checkout@v2; update commit/push step

### DIFF
--- a/.github/workflows/fetch-build-publish.yml
+++ b/.github/workflows/fetch-build-publish.yml
@@ -3,8 +3,8 @@ name: Build statusboard
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 1 * * *'
-      
+    - cron: "0 1 * * *"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -12,24 +12,22 @@ jobs:
       matrix:
         node-version: [12.x]
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install, fetch & build
-      run: |
-        npm ci
-        npm run fetch
-        npm run build
-      env:
-        AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Commit files
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git commit -m "feat: build changes" -a  
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install, fetch & build
+        env:
+          AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm ci
+          npm run fetch
+          npm run build
+      - name: Commit/Push Files
+        run: |
+          # Git Commands
+          git config --local user.email "ops+npm-deploy-user@npmjs.com"
+          git config --local user.name "beep boop I am a robot"
+          git commit -m "feat: build changes" -a
+          git push origin master


### PR DESCRIPTION
# What / Why
<!-- Describe the request in detail -->
The current GitHub Pages build/deploy is failing on the `master` branch:
![image](https://user-images.githubusercontent.com/2818462/72382959-5daaab00-36e8-11ea-94dd-4c4c21f6b2f0.png)

Likely, it's due to this rational:
![image](https://user-images.githubusercontent.com/2818462/72382925-4ff52580-36e8-11ea-9ddb-b95e8782129a.png)

The process inside the workflow is using the following details:

```yaml
    - name: Commit files
      run: |
        git config --local user.email "action@github.com"
        git config --local user.name "GitHub Action"
        git commit -m "feat: build changes" -a  
    - name: Push changes
      uses: ad-m/github-push-action@master
      with:
        github_token: ${{ secrets.GITHUB_TOKEN }}
```

Which is producing this commit data:
![image](https://user-images.githubusercontent.com/2818462/72383014-7e730080-36e8-11ea-97b0-885511ae0905.png)

This is enough permission (from the `GITHUB_TOKEN`) to commit to repository, but that email address isn't associated with the account.

---

This changes the the action to utilise `actions/checkout@v2` which saves the `${{ github.token }}` value into the `git` config, allowing you to make authenticated `git` commands inside the action. User information has also been changed to the `npm-deploy-user` account which does have admin access to this repository.


## References
<!-- Examples
  * Related to #0
  * Depends on #0
  * Blocked by #0
  * Closes #0
-->
* Fixes: https://github.com/npm/statusboard/issues/46

## Furthermore

If this pull-request doesn't fix the deployment issue then adding the following lines of code to the workflow file:

```yaml
- uses: actions/checkout@v2
  with:
    token: ${{ secrets.NPM_DEPLOY_USER_PAT }}
```

as well as adding the `NPM_DEPLOY_USER_PAT` as a secret to this repo _(in addition to the changes in this pull-request)_ will definitely solve the issue, as that account token does have admin permissions to this repository, as well as correct email/user data in the workflow file.