### PR TITLE
chore: add private flag to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Community &amp; Open Source Statusboard",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "serve": "http-server ./public/",
     "fetch": "node ./scripts/fetch.js",


### PR DESCRIPTION
This will prevent us from accidentally trying to publish this non-package, and will allow us to programmatically differentiate between our package and non-package repos.
