### PR TITLE
Use official `actions/deploy-pages` Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,6 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: paper-spa/deploy-pages@main
+        uses: actions/deploy-pages@v1
         with:
           preview: ${{ github.event_name == 'pull_request_target' }}


### PR DESCRIPTION
The GitHub Pages team recently [upstreamed](https://github.com/actions/deploy-pages/pull/61) our `paper-spa/deploy-pages` support for Pages preview sites to the official `actions/deploy-pages` Action.

Although it is still **only available as a limited alpha**, we didn't want to incur too much feature drift between the two repositories. Additionally, this alpha feature has already been mentioned in public forums prior to now, so it's no secret.

You may now utilize the preview deployments feature using any of the following `uses` configurations in your Actions workflow (from most specific/secure to least):

```
uses: actions/deploy-pages@c2379ec5e719a934ec613038d081879b58c9d7df
uses: actions/deploy-pages@v1.1.0
uses: actions/deploy-pages@v1
uses: actions/deploy-pages@main
```

Feel free to update your workflow to utilize any alternative version mentioned above instead of the one I've suggested here. 😊 

## References

N/A