### PR TITLE
fix: remove and update columns

### DIFF
--- a/workspaces/www/lib/js/selectors.js
+++ b/workspaces/www/lib/js/selectors.js
@@ -29,7 +29,6 @@ export const overrides = {
 // this is not portable but for now the template/node version checks
 // can be changed here or removed in the columns.js file
 export const templateOSS = (projects) => projects.find((p) => p.name === 'template-oss')
-export const templateVersion = (projects) => templateOSS(projects)?.version
 export const nodeVersion = (projects) => templateOSS(projects)?.node
 
 export const colId = (col) => `${typeof col === 'string' ? col : col.name}:name`


### PR DESCRIPTION
- `Node`: text is now `Default` if it matches template-oss latest. Otherwise it shows the node version and is colored depending on if it is a subset of the default
- Removed: `Template`, `Archived` and `Default Branch` columns. All the work on those columns is completed. Dedependabot keeps template-oss up to date and we have been manually deprecating packages as we archive now.
- `Pending Release`: this column is now part of `Version` and will only display if there is a pending release, eg `1.0.0 / 2.0.0` if there is a pending `2.0.0` PR.

<img width="1539" alt="Screen Shot 2022-12-15 at 2 37 18 PM" src="https://user-images.githubusercontent.com/542108/207972469-80430aae-eb98-4bbc-9d1b-a5c7e9746f07.png">
