### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "::set-output name=has_changes::1"
+            echo "has_changes=1" >> $GITHUB_OUTPUT
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'

--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "has_changes=1" >> $GITHUB_OUTPUT
+            echo "has_changes=1" >> "$GITHUB_OUTPUT"
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'

--- a/.github/workflows/fetch-maintained.yml
+++ b/.github/workflows/fetch-maintained.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "::set-output name=has_changes::1"
+            echo "has_changes=1" >> $GITHUB_OUTPUT
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'

--- a/.github/workflows/fetch-maintained.yml
+++ b/.github/workflows/fetch-maintained.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "has_changes=1" >> $GITHUB_OUTPUT
+            echo "has_changes=1" >> "$GITHUB_OUTPUT"
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -51,11 +51,11 @@ jobs:
         run: |
           dependabot_dir="${{ steps.metadata.outputs.directory }}"
           if [[ "$dependabot_dir" == "/" ]]; then
-            echo "workspace=-iwr" >> $GITHUB_OUTPUT
+            echo "workspace=-iwr" >> "$GITHUB_OUTPUT"
           else
             # strip leading slash from directory so it works as a
             # a path to the workspace flag
-            echo "workspace=-w ${dependabot_dir#/}" >> $GITHUB_OUTPUT
+            echo "workspace=-w ${dependabot_dir#/}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Apply Changes
@@ -64,7 +64,7 @@ jobs:
         run: |
           npm run template-oss-apply ${{ steps.flags.outputs.workspace }}
           if [[ `git status --porcelain` ]]; then
-            echo "changes=true" >> $GITHUB_OUTPUT
+            echo "changes=true" >> "$GITHUB_OUTPUT"
           fi
           # This only sets the conventional commit prefix. This workflow can't reliably determine
           # what the breaking change is though. If a BREAKING CHANGE message is required then
@@ -74,7 +74,7 @@ jobs:
           else
             prefix='chore'
           fi
-          echo "message=$prefix: postinstall for dependabot template-oss PR" >> $GITHUB_OUTPUT
+          echo "message=$prefix: postinstall for dependabot template-oss PR" >> "$GITHUB_OUTPUT"
 
       # This step will fail if template-oss has made any workflow updates. It is impossible
       # for a workflow to update other workflows. In the case it does fail, we continue


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


