### PR TITLE
deps: bump bootstrap from 4.6.2 to 5.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2561,6 +2561,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@sigstore/bundle": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-2.3.1.tgz",
@@ -3091,9 +3101,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-      "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "funding": [
         {
           "type": "github",
@@ -3105,8 +3115,7 @@
         }
       ],
       "peerDependencies": {
-        "jquery": "1.9.1 - 3",
-        "popper.js": "^1.16.1"
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootstrap-icons": {
@@ -8769,17 +8778,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/portfinder": {
       "version": "1.0.32",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
@@ -13368,7 +13366,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "bootstrap": "^4.6.2",
+        "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.9.1",
         "data": "^1.0.0",
         "datatables.net": "^2.0.7",

--- a/workspaces/www/lib/js/html.js
+++ b/workspaces/www/lib/js/html.js
@@ -17,7 +17,7 @@ export const link = ({ class: c = '', href, text, title }) =>
   `<a href="${href}" class="${c}" ${title ? `title="${title}"` : ''}>${text}</a>`
 
 export const badge = ({ type, href, text, title }) => {
-  const classes = `badge badge-dt badge-${type}`
+  const classes = `badge badge-dt text-bg-${type}`
   return href
     ? link({ class: classes, href, text, title })
     : `<div class="${classes}" ${title ? `title="${title}"` : ''}>${text}</div>`

--- a/workspaces/www/package.json
+++ b/workspaces/www/package.json
@@ -47,7 +47,7 @@
     "content": "../../scripts/template-oss"
   },
   "dependencies": {
-    "bootstrap": "^4.6.2",
+    "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.9.1",
     "data": "^1.0.0",
     "datatables.net": "^2.0.7",


### PR DESCRIPTION
This PR bumps `bootstrap` from 4.6.2 to 5.2.3