### PR TITLE
fix: swap from the deprecated action command to output file

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -36,7 +36,7 @@ jobs:
         id: status
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            echo "::set-output name=has_changes::1"
+            echo "has_changes=1" >> $GITHUB_OUTPUT
           fi
       - name: Commit changes
         if: steps.status.outputs.has_changes == '1'


### PR DESCRIPTION
the set-output command is deprecated: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/