### PR TITLE
fix: grant pages permissions to fetch-data publish job

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -10,6 +10,8 @@ jobs:
   fetch:
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      contents: write
     outputs:
       has_changes: ${{ steps.status.outputs.has_changes }}
     steps:
@@ -48,4 +50,8 @@ jobs:
   publish:
     needs: fetch
     if: needs.fetch.outputs.has_changes == '1'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
The reusable publish.yml workflow contains a `deploy` job that needs `pages: write` and `id-token: write` to deploy to GitHub Pages. When invoked from fetch-data.yml, those permissions were not granted because the repository default workflow permissions are read-only, causing a workflow startup failure:

  Error calling workflow '.../publish.yml'. The nested job 'deploy' is requesting 'pages: write, id-token: write', but is only allowed 'pages: none, id-token: none'.

Adds explicit per-job permissions so the fetch job can still push the data commit (`contents: write`) and the nested publish workflow has the permissions it needs.
