### PR TITLE
Security: Potential Prototype Pollution in p-all.js

### DIFF
--- a/workspaces/data/lib/p-all.js
+++ b/workspaces/data/lib/p-all.js
@@ -7,6 +7,9 @@ export default async (promises) => {
   for (const p of promisesArr) {
     if (isObj) {
       const [key, value] = p
+      if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+        continue
+      }
       if (typeof value === 'function') {
         result.push(await value().then(v => [key, v]))
       } else {


### PR DESCRIPTION
## Summary

Security: Potential Prototype Pollution in p-all.js

## Problem

**Severity**: `Medium` | **File**: `workspaces/data/lib/p-all.js:L5`

In workspaces/data/lib/p-all.js, the function uses `Object.entries(promises)` and later `Object.fromEntries(result)`. If user-controlled input is passed as the `promises` object, and the object contains keys like `__proto__`, `constructor`, or `prototype`, this could lead to prototype pollution when `Object.fromEntries` is called. While the current usage may be internal, the function is exported and could be used with untrusted input.

## Solution

Add validation to reject dangerous keys (`__proto__`, `constructor`, `prototype`) before processing, or use a null prototype object (`Object.create(null)`) to prevent prototype pollution.

## Changes

- `workspaces/data/lib/p-all.js` (modified)